### PR TITLE
Remove inline menu toggle attribute

### DIFF
--- a/assets/partials/header.html
+++ b/assets/partials/header.html
@@ -2,7 +2,7 @@
   <div class="nav-container">
     <div class="site-title">Maricel Bujoreanu</div>
 
-    <button class="menu-toggle" aria-label="Toggle Menu" onclick="toggleMenu()">
+    <button class="menu-toggle" aria-label="Toggle Menu">
       <span class="bar"></span>
       <span class="bar"></span>
       <span class="bar"></span>


### PR DESCRIPTION
## Summary
- remove the inline `onclick` handler from the header burger button

## Testing
- `grep -n toggleMenu assets/partials/header.html`

------
https://chatgpt.com/codex/tasks/task_e_685782d7f9e88330845dc979e1a8caec