### PR TITLE
Fix dropdown causing horizontal scroll

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,6 +20,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  overflow-x: hidden; /* Prevent horizontal scroll when dropdown opens */
 }
 
 /* Container for page content */


### PR DESCRIPTION
## Summary
- prevent dropdown from widening the page by hiding horizontal overflow on `.site-wrapper`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685784607f048330acf4c54367e540c1