### PR TITLE
Fix mobile menu toggle

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -203,6 +203,11 @@ main {
     text-align: left;
   }
 
+  /* Disable hover open behavior on small screens */
+  .dropdown:hover .dropdown-menu {
+    display: none;
+  }
+
   
 
   .dropdown.open .dropdown-menu {

--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -35,9 +35,7 @@ function setupMenuToggle() {
       if (window.innerWidth <= 768) {
         e.preventDefault();
         const isOpen = dropdown.classList.contains('open');
-        // Close all other dropdowns first
         dropdowns.forEach(d => d.classList.remove('open'));
-        // Toggle current one
         if (!isOpen) {
           dropdown.classList.add('open');
         }
@@ -52,6 +50,14 @@ function setupMenuToggle() {
       if (!isClickInside) {
         document.querySelectorAll('.dropdown.open').forEach(d => d.classList.remove('open'));
       }
+    }
+  });
+
+  // Reset menu state when resizing to desktop
+  window.addEventListener('resize', function () {
+    if (window.innerWidth > 768) {
+      navLinks.classList.remove('show');
+      dropdowns.forEach(d => d.classList.remove('open'));
     }
   });
 }


### PR DESCRIPTION
## Summary
- disable hover-based dropdown on small screens
- reset mobile menu state when resizing window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68578551b85083308ffc2055696422c6