### PR TITLE
Fix mobile menu initial state

### DIFF
--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -19,6 +19,11 @@ function setupMenuToggle() {
   const toggle = document.querySelector(".menu-toggle");
   const navLinks = document.querySelector(".nav-links");
 
+  // Ensure menu starts closed when the header loads
+  if (navLinks) {
+    navLinks.classList.remove("show");
+  }
+
   if (toggle && navLinks) {
     toggle.addEventListener("click", () => {
       navLinks.classList.toggle("show");


### PR DESCRIPTION
## Summary
- ensure `.nav-links` does not start with the `show` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857873216e083309a747e9139041ac1