### PR TITLE
Fix mobile dropdown hover

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -206,6 +206,8 @@ main {
   /* Disable hover open behavior on small screens */
   .dropdown:hover .dropdown-menu {
     display: none;
+    opacity: 0;
+    visibility: hidden;
   }
 
   


### PR DESCRIPTION
## Summary
- disable mobile hover dropdown with opacity & visibility

## Testing
- `npm install puppeteer`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857872a94448330a87b7f45faca0929