### PR TITLE
Fix mobile nav toggle

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -169,7 +169,8 @@ main {
     margin-bottom: 0.5rem;
   }
 
-  .nav-links {
+  /* Ensure mobile nav starts hidden */
+  .nav-menu .nav-links {
     display: none;
     flex-direction: column;
     gap: 0.75rem;
@@ -178,7 +179,7 @@ main {
     padding: 1rem 0;
   }
 
-  .nav-links.show {
+  .nav-menu .nav-links.show {
     display: flex;
   }
 


### PR DESCRIPTION
## Summary
- keep nav collapsed by default on mobile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857892124d0833085098c78f1bac9c4