### PR TITLE
Fix dropdown visibility on mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -215,6 +215,8 @@ main {
 
   .dropdown.open .dropdown-menu {
     display: block;
+    opacity: 1;
+    visibility: visible;
   }
 
   .site-title {

--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -30,6 +30,9 @@ function setupMenuToggle() {
   if (toggle && navLinks) {
     toggle.addEventListener("click", () => {
       navLinks.classList.toggle("show");
+      if (!navLinks.classList.contains("show")) {
+        document.querySelectorAll('.dropdown.open').forEach(d => d.classList.remove('open'));
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- keep dropdown menus hidden when closing the hamburger menu
- ensure opened dropdown menus are visible on small screens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68578a5bbef08330a54cc94f989f9184