### PR TITLE
Disable nav hover on mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -204,6 +204,13 @@ main {
     text-align: left;
   }
 
+  /* Remove hover styles for links in the mobile hamburger menu */
+  .nav-menu a:hover,
+  .dropdown-menu a:hover {
+    text-decoration: none;
+    background-color: inherit;
+  }
+
   /* Disable hover open behavior on small screens */
   .dropdown:hover .dropdown-menu {
     display: none;


### PR DESCRIPTION
## Summary
- remove hover effects in the hamburger menu so dropdowns don't flicker on touch devices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68578b9e4ee88330ab4d68cb79882912