### PR TITLE
Fix hover state in mobile menu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -204,9 +204,13 @@ main {
     text-align: left;
   }
 
-  /* Remove hover styles for links in the mobile hamburger menu */
+  /* Remove hover-like styles for links in the mobile hamburger menu */
   .nav-menu a:hover,
-  .dropdown-menu a:hover {
+  .nav-menu a:focus,
+  .nav-menu a:active,
+  .dropdown-menu a:hover,
+  .dropdown-menu a:focus,
+  .dropdown-menu a:active {
     text-decoration: none;
     background-color: inherit;
   }


### PR DESCRIPTION
## Summary
- prevent `hover` styling from persisting on dropdown links when viewed on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68578cb4735483309c9cf0c686a4eb4e