### PR TITLE
Add .env and build dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 node_modules/
+
+# Environment files
+.env
+
+# Build output
+build/
+dist/


### PR DESCRIPTION
## Summary
- extend `.gitignore` to exclude environment files and build output folders

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68579679fbbc8330a1120d4302059872