### PR TITLE
Fix hamburger menu visibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -108,10 +108,12 @@ main {
 }
 
 .menu-toggle .bar {
+  display: block;
   height: 3px;
   width: 100%;
   background-color: #fff;
   border-radius: 2px;
+  margin: 3px 0;
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- display hamburger icon spans on all pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68585f6e88a08330931ee2978521d6eb